### PR TITLE
baseline rules syntax checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A baseline-rule file is a YAML file containing a list of Rule objects, and each 
 
 |Property   |Description     |Type  |Default|
 |-----------|----------------|------|-------|
-|name       |Rule name       |string|`<no name>`|
+|name       |Rule name. Must match the requirements of [K8s DNS Subdomain Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)|string|`no-name`|
 |description|Rule description|string|`''`|
 |action     |Whether to allow or deny the specified connections. Either `allow` or `deny`|string|`allow`|
 |from       |Connections source. Either a [K8s set-based requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) or a [CIDR](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ipblock-v1-networking-k8s-io)|string|`null` (all sources)|
@@ -12,7 +12,7 @@ A baseline-rule file is a YAML file containing a list of Rule objects, and each 
 |from_ns    |Source Namespaces. a [K8s set-based requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)|string|`null` (all source namespaces)|
 |to_ns    |Destination Namespaces. a [K8s set-based requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)|string|`null` (all destination namespaces)|
 |protocol   |Connections protocol. Must be [supported by K8s](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicyport-v1-networking-k8s-io).|string|`null` (all protocols)|
-|port_min   |Minimal connections port|int|`null` (no minimal port)|
-|port_max   |Maximal connections port|int|`null` (no maximal port)|
+|port_min   |Minimal connections port. Must be in range of [1, 65535]|int|`null` (no minimal port)|
+|port_max   |Maximal connections port. Must be in range of [1, 65535]|int|`null` (no maximal port)|
 
 Examples are available in the [examples directory](https://github.com/np-guard/baseline-rules/tree/master/examples).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A baseline-rule file is a YAML file containing a list of Rule objects, and each 
 |from_ns    |Source Namespaces. a [K8s set-based requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)|string|`null` (all source namespaces)|
 |to_ns    |Destination Namespaces. a [K8s set-based requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)|string|`null` (all destination namespaces)|
 |protocol   |Connections protocol. Must be [supported by K8s](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicyport-v1-networking-k8s-io).|string|`null` (all protocols)|
-|port_min   |Minimal connections port. Must be in range of [1, 65535]|int|`null` (no minimal port)|
-|port_max   |Maximal connections port. Must be in range of [1, 65535]|int|`null` (no maximal port)|
+|port_min   |Minimal connections port. Must be in range [1, 65535]|int|`null` (no minimal port)|
+|port_max   |Maximal connections port. Must be in range [1, 65535]|int|`null` (no maximal port)|
 
 Examples are available in the [examples directory](https://github.com/np-guard/baseline-rules/tree/master/examples).

--- a/src/baseline_rule.py
+++ b/src/baseline_rule.py
@@ -30,10 +30,10 @@ class BaselineRule:
     """
 
     def __init__(self, rule_record):
+        RuleSyntaxChecker.check_keys_legality(rule_record)
+        self.name = RuleSyntaxChecker.check_dns_subdomain_name(rule_record.get('name', 'no-name'))
+        self.description = rule_record.get('description', '')
         try:
-            RuleSyntaxChecker.check_keys_legality(rule_record)
-            self.name = RuleSyntaxChecker.check_dns_subdomain_name(rule_record.get('name', 'no-name'))
-            self.description = rule_record.get('description', '')
             self.action = \
                 BaselineRuleAction[RuleSyntaxChecker.check_action_validity(rule_record.get('action', 'allow'))]
             self.source = \
@@ -48,9 +48,9 @@ class BaselineRule:
             self.port_max = RuleSyntaxChecker.check_port_validity(rule_record.get('port_max'))
         except Exception as e:
             if self.name:
-                print(f'{self.name} : {e}')
+                raise Exception(f'{self.name} : {e}') from None
             else:
-                print(e)
+                raise Exception(e) from None
 
         self.check_selectors_entries_combinations()
 

--- a/src/baseline_rule.py
+++ b/src/baseline_rule.py
@@ -33,6 +33,8 @@ class BaselineRule:
         self.name = rule_record.get('name', 'no-name')
         self.description = rule_record.get('description', '')
         try:
+            RuleSyntaxChecker.check_keys_legality(rule_record)
+            RuleSyntaxChecker.check_dns_subdomain_name(self.name)
             self.action = \
                 BaselineRuleAction[RuleSyntaxChecker.check_action_validity(rule_record.get('action', 'allow'))]
             self.source = \

--- a/src/baseline_rule.py
+++ b/src/baseline_rule.py
@@ -47,10 +47,7 @@ class BaselineRule:
             self.port_min = RuleSyntaxChecker.check_port_validity(rule_record.get('port_min'))
             self.port_max = RuleSyntaxChecker.check_port_validity(rule_record.get('port_max'))
         except Exception as e:
-            if self.name:
-                raise Exception(f'{self.name} : {e}') from None
-            else:
-                raise Exception(e) from None
+            raise Exception(f'{self.name} : {e}') from None
 
         self.check_selectors_entries_combinations()
 

--- a/src/baseline_rule.py
+++ b/src/baseline_rule.py
@@ -30,20 +30,28 @@ class BaselineRule:
     """
 
     def __init__(self, rule_record):
-        syntax_checker = RuleSyntaxChecker()
-        syntax_checker.check_keys_legality(rule_record)
-        self.name = syntax_checker.check_dns_subdomain_name(rule_record.get('name', 'no-name'))
-        self.description = rule_record.get('description', '')
-        self.action = BaselineRuleAction[syntax_checker.check_action_validity(rule_record.get('action', 'allow'))]
-        self.source = syntax_checker.check_selector_validity(Selector.parse_selectors(rule_record.get('from', '')))
-        self.target = syntax_checker.check_selector_validity(Selector.parse_selectors(rule_record.get('to', '')))
-        self.source_ns = \
-            syntax_checker.check_namespace_selector_validity(Selector.parse_selectors(rule_record.get('from_ns', '')))
-        self.target_ns = \
-            syntax_checker.check_namespace_selector_validity(Selector.parse_selectors(rule_record.get('to_ns', '')))
-        self.protocol = syntax_checker.check_protocol_validity(rule_record.get('protocol'))
-        self.port_min = syntax_checker.check_port_validity(rule_record.get('port_min'))
-        self.port_max = syntax_checker.check_port_validity(rule_record.get('port_max'))
+        try:
+            RuleSyntaxChecker.check_keys_legality(rule_record)
+            self.name = RuleSyntaxChecker.check_dns_subdomain_name(rule_record.get('name', 'no-name'))
+            self.description = rule_record.get('description', '')
+            self.action = \
+                BaselineRuleAction[RuleSyntaxChecker.check_action_validity(rule_record.get('action', 'allow'))]
+            self.source = \
+                RuleSyntaxChecker.check_selector_validity(Selector.parse_selectors(rule_record.get('from', '')))
+            self.target = RuleSyntaxChecker.check_selector_validity(Selector.parse_selectors(rule_record.get('to', '')))
+            self.source_ns = RuleSyntaxChecker.\
+                check_namespace_selector_validity(Selector.parse_selectors(rule_record.get('from_ns', '')))
+            self.target_ns = RuleSyntaxChecker.\
+                check_namespace_selector_validity(Selector.parse_selectors(rule_record.get('to_ns', '')))
+            self.protocol = RuleSyntaxChecker.check_protocol_validity(rule_record.get('protocol'))
+            self.port_min = RuleSyntaxChecker.check_port_validity(rule_record.get('port_min'))
+            self.port_max = RuleSyntaxChecker.check_port_validity(rule_record.get('port_max'))
+        except Exception as e:
+            if self.name:
+                print(f'{self.name} : {e}')
+            else:
+                print(e)
+
         self.check_selectors_entries_combinations()
 
     def check_selectors_entries_combinations(self):

--- a/src/baseline_rule.py
+++ b/src/baseline_rule.py
@@ -46,10 +46,9 @@ class BaselineRule:
             self.protocol = RuleSyntaxChecker.check_protocol_validity(rule_record.get('protocol'))
             self.port_min = RuleSyntaxChecker.check_port_validity(rule_record.get('port_min'))
             self.port_max = RuleSyntaxChecker.check_port_validity(rule_record.get('port_max'))
+            self.check_selectors_entries_combinations()
         except Exception as e:
             raise Exception(f'{self.name} : {e}') from None
-
-        self.check_selectors_entries_combinations()
 
     def check_selectors_entries_combinations(self):
         if isinstance(self.source, IpSelector) and self.source_ns:

--- a/src/baseline_rule.py
+++ b/src/baseline_rule.py
@@ -30,8 +30,7 @@ class BaselineRule:
     """
 
     def __init__(self, rule_record):
-        RuleSyntaxChecker.check_keys_legality(rule_record)
-        self.name = RuleSyntaxChecker.check_dns_subdomain_name(rule_record.get('name', 'no-name'))
+        self.name = rule_record.get('name', 'no-name')
         self.description = rule_record.get('description', '')
         try:
             self.action = \

--- a/src/basline_rule_syntax_checker.py
+++ b/src/basline_rule_syntax_checker.py
@@ -45,7 +45,7 @@ class RuleSyntaxChecker:
         if not isinstance(port_num, int):
             raise Exception(f'Invalid {port_num}. A port must be numerical', self.rule_name)
         if port_num not in range(1, 65536):
-            raise Exception(f'Invalid {port_num}. A port must be in the range of [1, 65535]', self.rule_name)
+            raise Exception(f'Invalid {port_num}. A port must be in the range [1, 65535]', self.rule_name)
 
         return port_num
 

--- a/src/basline_rule_syntax_checker.py
+++ b/src/basline_rule_syntax_checker.py
@@ -7,9 +7,6 @@ class RuleSyntaxChecker:
     This class make syntax and validity checks on baseline rule's fields
     """
 
-    def __init__(self):
-        self.rule_name = ''
-
     @staticmethod
     def check_keys_legality(rule_record):
         allowed_keys = {'name', 'description', 'action', 'from', 'to', 'from_ns', 'to_ns',
@@ -20,7 +17,8 @@ class RuleSyntaxChecker:
             raise Exception(f'{bad_match_keys.pop()} is not a valid entry in the specification of a baseline rule',
                             rule_record)
 
-    def check_dns_subdomain_name(self, rule_name):
+    @staticmethod
+    def check_dns_subdomain_name(rule_name):
         if len(rule_name) > 253:
             raise Exception(f'Rule name {rule_name} does not match requirements of k8s DNS subdomain name. '
                             f'It must be no more than 253 characters')
@@ -30,50 +28,55 @@ class RuleSyntaxChecker:
                             f'it must consist of lower case alphanumeric characters, "-" or ".", '
                             f'and must start and end with an alphanumeric character')
 
-        self.rule_name = rule_name
         return rule_name
 
-    def check_action_validity(self, rule_action):
+    @staticmethod
+    def check_action_validity(rule_action):
         if rule_action not in ('allow', 'deny'):
             raise Exception(f'{rule_action} action is not supported. '
-                            f'Baseline rule supports only allow and deny actions', self.rule_name)
+                            f'Baseline rule supports only allow and deny actions')
         return rule_action
 
-    def check_port_validity(self, port_num):
+    @staticmethod
+    def check_port_validity(port_num):
         if port_num is None:
             return None
         if not isinstance(port_num, int):
-            raise Exception(f'Invalid {port_num}. A port must be numerical', self.rule_name)
+            raise Exception(f'Invalid {port_num}. A port must be numerical')
         if port_num not in range(1, 65536):
-            raise Exception(f'Invalid {port_num}. A port must be in the range [1, 65535]', self.rule_name)
+            raise Exception(f'Invalid {port_num}. A port must be in the range [1, 65535]')
 
         return port_num
 
-    def check_protocol_validity(self, protocol):
+    @staticmethod
+    def check_protocol_validity(protocol):
         if not protocol:
             return None
         if protocol not in ('TCP', 'UDP', 'SCTP'):
-            raise Exception(f'{protocol} protocol is not supported', self.rule_name)
+            raise Exception(f'{protocol} protocol is not supported')
         return protocol
 
-    def check_selector_validity(self, selectors):
+    @staticmethod
+    def check_selector_validity(selectors):
         if not selectors:
             return selectors
         if isinstance(selectors, IpSelector):
             return selectors
         for sel in selectors:
-            self.check_label_key_syntax(sel.key, sel)
+            RuleSyntaxChecker._check_label_key_syntax(sel.key, sel)
             if sel.values:
                 for value in sel.values:
-                    self.check_label_value_syntax(value, sel.key, selectors)
+                    RuleSyntaxChecker._check_label_value_syntax(value, sel.key, selectors)
         return selectors
 
-    def check_namespace_selector_validity(self, ns_selector):
+    @staticmethod
+    def check_namespace_selector_validity(ns_selector):
         if isinstance(ns_selector, IpSelector):
-            raise Exception('A namespaceSelector can not be specified in CIDR notation', self.rule_name)
-        return self.check_selector_validity(ns_selector)
+            raise Exception('A namespaceSelector can not be specified in CIDR notation')
+        return RuleSyntaxChecker.check_selector_validity(ns_selector)
 
-    def check_label_key_syntax(self, key_label, key_container):
+    @staticmethod
+    def _check_label_key_syntax(key_label, key_container):
         """
         checking validity of the label's key
         :param string key_label: The key name
@@ -81,30 +84,31 @@ class RuleSyntaxChecker:
         :return: None
         """
         if key_label.count('/') > 1:
-            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", a valid label key may have two segments: '
+            raise Exception(f'Invalid key "{key_label}", a valid label key may have two segments: '
                             f'an optional prefix and name, separated by a slash (/).', key_container)
         if key_label.count('/') == 1:
             prefix = key_label.split('/')[0]
             if not prefix:
-                raise Exception(f'{self.rule_name}: Invalid key "{key_label}", prefix part must be non-empty',
+                raise Exception(f'Invalid key "{key_label}", prefix part must be non-empty',
                                 key_container)
-            self.check_dns_subdomain_name(prefix)
+            RuleSyntaxChecker.check_dns_subdomain_name(prefix)
             name = key_label.split('/')[1]
         else:
             name = key_label
         if not name:
-            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", '
+            raise Exception(f'Invalid key "{key_label}", '
                             f'name segment is required in label key', key_container)
         if len(name) > 63:
-            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", '
+            raise Exception(f'Invalid key "{key_label}", '
                             f'a label key name must be no more than 63 characters', key_container)
         pattern = r"([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
         if re.fullmatch(pattern, name) is None:
-            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", '
+            raise Exception(f'Invalid key "{key_label}", '
                             f'a label key name part must consist of alphanumeric characters, "-", "_" or ".", '
                             f'and must start and end with an alphanumeric character', key_container)
 
-    def check_label_value_syntax(self, val, key, key_container):
+    @staticmethod
+    def _check_label_value_syntax(val, key, key_container):
         """
         checking validity of the label's value
         :param string val : the value to be checked
@@ -113,13 +117,13 @@ class RuleSyntaxChecker:
         :return: None
         """
         if val is None:
-            raise Exception(f'{self.rule_name}: Value label of "{key}" can not be null', key_container)
+            raise Exception(f'Value label of "{key}" can not be null', key_container)
         if val:
             if len(val) > 63:
-                raise Exception(f'{self.rule_name}: Invalid value "{val}" for "{key}", '
+                raise Exception(f'Invalid value "{val}" for "{key}", '
                                 f'a label value must be no more than 63 characters', key_container)
             pattern = r"(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
             if re.fullmatch(pattern, val) is None:
-                raise Exception(f'{self.rule_name}: Invalid value "{val}" for "{key}", '
+                raise Exception(f'Invalid value "{val}" for "{key}", '
                                 f'value label must be an empty string or consist of alphanumeric characters, "-", "_" '
                                 f'or ".", and must start and end with an alphanumeric character ', key_container)

--- a/src/basline_rule_syntax_checker.py
+++ b/src/basline_rule_syntax_checker.py
@@ -1,0 +1,125 @@
+import re
+from selector import IpSelector
+
+
+class RuleSyntaxChecker:
+    """
+    This class make syntax and validity checks on baseline rule's fields
+    """
+
+    def __init__(self):
+        self.rule_name = ''
+
+    @staticmethod
+    def check_keys_legality(rule_record):
+        allowed_keys = {'name', 'description', 'action', 'from', 'to', 'from_ns', 'to_ns',
+                        'protocol', 'port_min', 'port_max'}
+        record_keys = set(rule_record.keys())
+        bad_match_keys = record_keys.difference(allowed_keys)
+        if bad_match_keys:
+            raise Exception(f'{bad_match_keys.pop()} is not a valid entry in the specification of a baseline rule',
+                            rule_record)
+
+    def check_dns_subdomain_name(self, rule_name):
+        if len(rule_name) > 253:
+            raise Exception(f'Rule name {rule_name} does not match requirements of k8s DNS subdomain name. '
+                            f'It must be no more than 253 characters')
+        pattern = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+        if re.fullmatch(pattern, rule_name) is None:
+            raise Exception(f'Rule name {rule_name} does not match requirements of k8s DNS subdomain name. '
+                            f'it must consist of lower case alphanumeric characters, "-" or ".", '
+                            f'and must start and end with an alphanumeric character')
+
+        self.rule_name = rule_name
+        return rule_name
+
+    def check_action_validity(self, rule_action):
+        if rule_action not in ('allow', 'deny'):
+            raise Exception(f'{rule_action} action is not supported. '
+                            f'Baseline rule supports only allow and deny actions', self.rule_name)
+        return rule_action
+
+    def check_port_validity(self, port_num):
+        if port_num is None:
+            return None
+        if not isinstance(port_num, int):
+            raise Exception(f'Invalid {port_num}. A port must be numerical', self.rule_name)
+        if port_num not in range(1, 65536):
+            raise Exception(f'Invalid {port_num}. A port must be in the range of [1, 65535]', self.rule_name)
+
+        return port_num
+
+    def check_protocol_validity(self, protocol):
+        if not protocol:
+            return None
+        if protocol not in ('TCP', 'UDP', 'SCTP'):
+            raise Exception(f'{protocol} protocol is not supported', self.rule_name)
+        return protocol
+
+    def check_selector_validity(self, selectors):
+        if not selectors:
+            return selectors
+        if isinstance(selectors, IpSelector):
+            return selectors
+        for sel in selectors:
+            self.check_label_key_syntax(sel.key, sel)
+            if sel.values:
+                for value in sel.values:
+                    self.check_label_value_syntax(value, sel.key, selectors)
+        return selectors
+
+    def check_namespace_selector_validity(self, ns_selector):
+        if isinstance(ns_selector, IpSelector):
+            raise Exception('A namespaceSelector can not be specified in CIDR notation', self.rule_name)
+        return self.check_selector_validity(ns_selector)
+
+    def check_label_key_syntax(self, key_label, key_container):
+        """
+        checking validity of the label's key
+        :param string key_label: The key name
+        :param dict key_container : The selector's part where the key appears
+        :return: None
+        """
+        if key_label.count('/') > 1:
+            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", a valid label key may have two segments: '
+                            f'an optional prefix and name, separated by a slash (/).', key_container)
+        if key_label.count('/') == 1:
+            prefix = key_label.split('/')[0]
+            if not prefix:
+                raise Exception(f'{self.rule_name}: Invalid key "{key_label}", prefix part must be non-empty',
+                                key_container)
+            self.check_dns_subdomain_name(prefix)
+            name = key_label.split('/')[1]
+        else:
+            name = key_label
+        if not name:
+            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", '
+                            f'name segment is required in label key', key_container)
+        if len(name) > 63:
+            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", '
+                            f'a label key name must be no more than 63 characters', key_container)
+        pattern = r"([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+        if re.fullmatch(pattern, name) is None:
+            raise Exception(f'{self.rule_name}: Invalid key "{key_label}", '
+                            f'a label key name part must consist of alphanumeric characters, "-", "_" or ".", '
+                            f'and must start and end with an alphanumeric character', key_container)
+
+    def check_label_value_syntax(self, val, key, key_container):
+        """
+        checking validity of the label's value
+        :param string val : the value to be checked
+        :param string key: The key name which the value is assigned for
+        :param dict key_container : The label selector's part where the key and val appear
+        :return: None
+        """
+        if val is None:
+            raise Exception(f'{self.rule_name}: Value label of "{key}" can not be null', key_container)
+        if val:
+            if len(val) > 63:
+                raise Exception(f'{self.rule_name}: Invalid value "{val}" for "{key}", '
+                                f'a label value must be no more than 63 characters', key_container)
+            pattern = r"(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
+            if re.fullmatch(pattern, val) is None:
+                raise Exception(f'{self.rule_name}: Invalid value "{val}" for "{key}", '
+                                f'value label must be an empty string or consist of alphanumeric characters, "-", "_" '
+                                f'or ".", and must start and end with an alphanumeric character ', key_container)


### PR DESCRIPTION
Hi,
I've added a new file for syntax checking methods.
However , methods that check the validity of k8s name, or selectors' strings are very similar to the "correspondent" methods used in nca's K8sPolicyYamlParser.py.
So, this raises a question if it is worth it to move these methods into a "utility" file or utility repo  that may be accessible from both repos/ np-guard repos? 